### PR TITLE
Replaced default plugin description

### DIFF
--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -2,5 +2,5 @@
   This view is used to render the installed plugins page.
 -->
 <div>
-  This plugin is a sample to explain how to write a Jenkins plugin.
+  This plugin allows quarantining of flakey tests.
 </div>


### PR DESCRIPTION
In the Jenkins Plugin Manager, the quarantine plugin were not displaying the right description. 
http://jenkins:8080/pluginManager/installed
